### PR TITLE
Rewrote parseTagLine; now correctly parses ctag lines with "/^" in the name section

### DIFF
--- a/lib/tag-generator.coffee
+++ b/lib/tag-generator.coffee
@@ -9,28 +9,16 @@ class TagGenerator
   constructor: (@path, @scopeName, @cmdArgs) ->
 
   parseTagLine: (line) ->
-    matches = line.match(/\/\^(.*)\$\/;"/)
-    if not matches
-      matches = line.match(/\/\^(.*)\/;"/)
-    return unless matches
+    sections = line.split('\t')
 
-    pattern = matches[1]
-    patternStr = matches[0]
+    name = sections[0]
+    file = sections[1]
+    middle = sections[2..-2].join('\t')
+    match = middle.match(/\/\^(.*)\$\/;"/)
+    pattern = match[1]
+    row = sections[sections.length - 1].match(/line:(\d+)/)?[1] - 1
 
-    idx = line.indexOf(patternStr)
-
-    start = line.substr(0, idx)
-    end = line.substr(idx + patternStr.length)
-
-    row = 0
-    row = end.match(/line:(\d+)/)?[1]
-    --row
-
-    sections = start.split(/\t+/)
-    name = sections[sections.length-3]
-    return unless name
-
-    file: sections[sections.length-2]
+    file: file
     position: new Point(row, pattern.indexOf(name))
     pattern: pattern
     name: name


### PR DESCRIPTION
The regex used in the original parseTagLine would sometimes encounter problems parsing lines which contained "/^" in the name field, before the filepath, such as when parsing Readme.md in https://github.com/busterjs/formatio ### `excludeConstructors (["Object", /^.$/])`

I've rewritten the function in a way which I hope will parse more consistently.

This is my first pull request, so I'm sorry for any mistakes!  I hope you'll fix the bug either way!
