### PR TITLE
Keymaps: Added keymap for toggling project symbols

### DIFF
--- a/keymaps/symbols-view.cson
+++ b/keymaps/symbols-view.cson
@@ -1,5 +1,6 @@
 '.platform-darwin .editor':
   'cmd-r': 'atom-ctags:toggle-file-symbols'
+  'cmd-shift-r': 'atom-ctags:toggle-project-symbols'
   'cmd-alt-down': 'atom-ctags:go-to-declaration'
   'cmd-alt-up': 'atom-ctags:return-from-declaration'
 
@@ -8,5 +9,6 @@
 
 '.platform-linux .editor':
   'ctrl-r': 'atom-ctags:toggle-file-symbols'
+  'ctrl-shift-r': 'atom-ctags:toggle-project-symbols'
   'ctrl-alt-down': 'atom-ctags:go-to-declaration'
   'ctrl-alt-up': 'atom-ctags:return-from-declaration'


### PR DESCRIPTION
Sure, it collides with the keymaps of `symbols-view`. But then again, so does `cmd-r`, `cmd-alt-up` and `cmd-alt-down` as well.