### PR TITLE
Do not show the symbol in a file view as it scrolls

### DIFF
--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -107,9 +107,6 @@ class FileView extends SymbolsView
     super
     return unless @cancelPosition
 
-    tag = @getSelectedItem()
-    @scrollToPosition(tag.position)
-
   scrollToPosition: (position, select = true)->
     if editor = atom.workspace.getActiveTextEditor()
       editor.scrollToBufferPosition(position, center: true)


### PR DESCRIPTION
Since it shows all the actual location of symbols
as ItemView is scrolled, it messes up the cursor history.

The benefit of showing the location of symbol instantly is not
worth losing the cursor history.

Signed-off-by: Jinkyu Song <jksong103@gmail.com>