### PR TITLE
handle clojure symbol syntax in getCurSymbol

### DIFF
--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -68,6 +68,8 @@ class FileView extends SymbolsView
     if cursor.getScopeDescriptor().getScopesArray().indexOf('source.ruby') isnt -1
       # Include ! and ? in word regular expression for ruby files
       range = cursor.getCurrentWordBufferRange(wordRegex: /[\w!?]*/g)
+    else if cursor.getScopeDescriptor().getScopesArray().indexOf('source.clojure') isnt -1
+      range = cursor.getCurrentWordBufferRange(wordRegex: /[\w\*\+!\-_'\?<>]([\w\*\+!\-_'\?<>\.:]+[\w\*\+!\-_'\?<>]?)?/g)
     else
       range = cursor.getCurrentWordBufferRange()
     return editor.getTextInRange(range)


### PR DESCRIPTION
Clojure variables can have pretty exotic names, which aren't currently handled by the `getCurSymbol` function.

This changeset adds a nasty regexp to clojure source files (it tries to implement [the clojure reader's symbol syntax definition] (http://clojure.org/reader)): 

- Symbols
  - Symbols begin with a non-numeric character and can contain alphanumeric characters and *, +, !, -, _, ', and ? (other characters may be allowed eventually).
  - '/' has special meaning, it can be used once in the middle of a symbol to separate the namespace from the name, e.g. my-namespace/foo. '/' by itself names the division function.
  - '.' has special meaning - it can be used one or more times in the middle of a symbol to designate a fully-qualified class name, e.g. java.util.BitSet, or in namespace names. Symbols beginning or ending with '.' are reserved by Clojure. Symbols containing / or . are said to be 'qualified'.
  - Symbols beginning or ending with ':' are reserved by Clojure. A symbol can contain one or more non-repeating ':'s.