### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 This package uses：
 [ctags](http://ctags.sourceforge.net),
-[autocomplete-plus](https://github.com/saschagehlich/autocomplete-plus)
+[autocomplete-plus](https://github.com/atom/autocomplete-plus)
 and fork from [symbols-view](https://github.com/atom/symbols-view)
 
 #Features


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/saschagehlich/autocomplete-plus | https://github.com/atom/autocomplete-plus 
