### PR TITLE
.dispose() all the disposables

### DIFF
--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -1,3 +1,4 @@
+{CompositeDisposable} = require 'atom'
 {$$} = require 'atom-space-pen-views'
 SymbolsView = require './symbols-view'
 
@@ -6,16 +7,16 @@ class FileView extends SymbolsView
   initialize: ->
     super
 
-    @editorsSubscription = atom.workspace.observeTextEditors (editor) =>
-      disposable = editor.onDidSave =>
+    @disposables = new CompositeDisposable()
+
+    @disposables.add atom.workspace.observeTextEditors (editor) =>
+      @disposables.add editor.onDidSave =>
         f = editor.getPath()
         return unless atom.project.contains(f)
         @ctagsCache.generateTags(f, true)
 
-      editor.onDidDestroy -> disposable.dispose()
-
   destroy: ->
-    @editorsSubscription.dispose()
+    @disposables.dispose()
     super
 
   viewForItem: ({lineNumber, name, file, pattern}) ->


### PR DESCRIPTION
- Reloading the package (e.g. with https://github.com/cakecatz/atom-hot-package-loader) would cause all of the commands to fire N times, once for each reload
- This applies `CompositeDisposable` on all `.on*` and `.add*` calls to properly dispose all disposables and fix that leakage