### PR TITLE
Filter on tag.name + tag.file, and relativize tag.file for more concise display

### DIFF
--- a/lib/ctags-cache.coffee
+++ b/lib/ctags-cache.coffee
@@ -40,18 +40,19 @@ module.exports =
 
     stream = ctags.createReadStream(p)
 
-    stream.on 'error', (error)->
+    stream.on 'error', (error) =>
       console.error 'atom-ctags: ', error
 
-    stream.on 'data', (tags)->
+    stream.on 'data', (tags) =>
       for tag in tags
         continue unless tag.pattern
         data = container[tag.file]
         if not data
           data = []
           container[tag.file] = data
+        @addFieldsToTag(tag)
         data.push tag
-    stream.on 'end', ()->
+    stream.on 'end', () =>
       console.log "[atom-ctags:readTags] #{p} cost: #{Date.now() - startTime}ms"
       callback?()
 
@@ -97,3 +98,10 @@ module.exports =
     @generateTags filePath, true, =>
       tags = @cachedTags[filePath]
       callback?(tags)
+
+  addFieldsToTag: (tag) ->
+    # Add .relFile, for .filterKey and for more concise display
+    [projectDir, relFile] = atom.workspace.project.relativizePath(tag.file)
+    tag.relFile = path.join(path.basename(projectDir), relFile)
+    # Add .filterKey, for FileView.getFilterKey
+    tag.filterKey = "#{tag.name} #{tag.relFile}"

--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -18,7 +18,9 @@ class FileView extends SymbolsView
     @editorsSubscription.dispose()
     super
 
-  viewForItem: ({lineNumber, name, file, pattern}) ->
+  getFilterKey: -> 'filterKey'
+
+  viewForItem: ({lineNumber, name, relFile, pattern}) ->
     $$ ->
       @li class: 'two-lines', =>
         @div class: 'primary-line', =>
@@ -27,7 +29,7 @@ class FileView extends SymbolsView
 
         @div class: 'secondary-line', =>
           @span "Line: #{lineNumber}", class: 'pull-left'
-          @span file, class: 'pull-right'
+          @span relFile, class: 'pull-right'
 
   toggle: ->
     if @panel.isVisible()


### PR DESCRIPTION
- In cases where a short symbol name matches many files, this lets you type both the symbol name and parts of the file paths to narrow down the results
  - e.g. if you're in a python setting and indexed all of your `site-packages`, then searching for `fft` will produce many results across numpy and scipy, and this change lets you augment your search like `fft numpy fftpack` to drill down using the file path
- This change also relativizes file paths like:
  - `atom-ctags/lib/file-view.coffee` instead of `/Users/bob/personal/atom/atom-ctags/lib/file-view.coffee`
  - `audio_thing/.site/numpy/fft/fftpack.py` instead of `/Users/bob/work/blue-team/audio_thing/.site/numpy/fft/fftpack.py`
