### PR TITLE
Add hyperclick provider

### DIFF
--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -87,14 +87,18 @@ class FileView extends SymbolsView
     if not symbol
       console.error "[atom-ctags:goto] failed getCurSymbol"
       return
+    @gotoSymbol(symbol)
 
+  gotoSymbol: (symbol) ->
     tags = @ctagsCache.findTags(symbol)
-
     if tags.length is 1
       @openTag(tags[0])
     else
       @setItems(tags)
-      @attach()
+      # @attach() works without a setTimeout when go-to-declaration is invoked by key command, but it fails (i.e.
+      # appears to do nothing) when invoked by a mousedown event or hyperclick provider. Adding the setTimeout(..., 0)
+      # makes all 3 cases work.
+      setTimeout((=> @attach()), 0)
 
   populate: (filePath) ->
     @list.empty()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -140,3 +140,18 @@ module.exports =
       @provider.ctagsCache = @ctagsCache
       @provider.disabled = atom.config.get('atom-ctags.disableComplete')
     @provider
+
+  # Docs: https://github.com/facebook-atom/atom-ide-ui/tree/master/modules/atom-ide-ui/pkg/hyperclick
+  provideHyperclick: ->
+    return
+      # Provide for all grammars
+      #grammarScopes: ...
+      # Be lowest priority, so that more specific hyperclick providers can override us
+      priority: -1
+      # TODO Is hyperclick's wordAtPosition more robust than our own FileView.getCurSymbol? Consider replacing ours if so.
+      getSuggestionForWord: (editor, text, range) =>
+        return
+          # Underline this range on cmd-hover, as a visual cue for clicking
+          range: range
+          # On cmd-click
+          callback: () => @createFileView().gotoSymbol(text)

--- a/package.json
+++ b/package.json
@@ -23,6 +23,11 @@
       "versions": {
         "2.0.0": "provide"
       }
+    },
+    "hyperclick": {
+      "versions": {
+        "0.1.0": "provideHyperclick"
+      }
     }
   }
 }


### PR DESCRIPTION
- This required factoring a new `gotoSymbol` method out from the existing `goto` method, which was simple
- See comments in code for other nuances