### PR TITLE
generateTags: Add a null check to warn instead of throwing

### DIFF
--- a/lib/ctags-cache.coffee
+++ b/lib/ctags-cache.coffee
@@ -76,6 +76,10 @@ module.exports =
     return false
 
   generateTags:(p, isAppend, callback) ->
+    if @cachedTags is null
+      console.warn('generateTags: @cachedTags is null, skipping')
+      return
+
     delete @cachedTags[p]
 
     startTime = Date.now()


### PR DESCRIPTION
- This kept triggering in dev so I added a guard to warn and ignore
- Not sure the root cause -- it could just be a spurious behavior from using atom-hot-package-loader, in which case it's just a harmless guard