### PR TITLE
making ctags run from project directory

### DIFF
--- a/lib/tag-generator.coffee
+++ b/lib/tag-generator.coffee
@@ -65,7 +65,10 @@ module.exports = (codepath, isAppend, cmdArgs, callback)->
 
     callback(genPath)
 
-  childProcess = new BufferedProcess({command, args, stderr, exit})
+  options =
+    cwd: projectPath
+
+  childProcess = new BufferedProcess({command, args, options, stderr, exit})
 
   timeout = atom.config.get('atom-ctags.buildTimeout')
   t = setTimeout ->


### PR DESCRIPTION
I'm using `--exclude=@.gitignore` setting in `~/.ctags.d/default.ctags`. It wasn't able to find project's `.gitignore` file, since by default `BufferedProcess` is starting from `/` directory. That simple PR fixes that. 

Really hope it'll make to next version ;) Thank you. 